### PR TITLE
added log on wrong block height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tmp
 dist/
 build
+.idea

--- a/chain/paloma/collision/zero_collision.go
+++ b/chain/paloma/collision/zero_collision.go
@@ -108,6 +108,10 @@ func GoStartLane(ctx context.Context, p palomer, me sdk.ValAddress) (context.Con
 				}
 				newBlockHeight = roundBlockHeight(newBlockHeight)
 				if newBlockHeight != blockHeight {
+					log.
+						WithField("blockHeight", blockHeight).
+						WithField("newBlockHeight", newBlockHeight).
+						Error("block height is unexpected")
 					return
 				}
 			case <-ctx.Done():

--- a/chain/paloma/collision/zero_collision.go
+++ b/chain/paloma/collision/zero_collision.go
@@ -93,8 +93,6 @@ func GoStartLane(ctx context.Context, p palomer, me sdk.ValAddress) (context.Con
 	ctx, cancelCtx := context.WithCancel(ctx)
 
 	go func() {
-		defer cancelCtx()
-
 		ticker := time.NewTicker(tickerTimeout)
 		defer ticker.Stop()
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/8

# Background

We add log to make sure that the context, cancelled when the block height is unexpected, affects getting logs from EVM

# Testing completed
